### PR TITLE
Implement custom sorting of leaf nodes in a tree

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: scala
+
+scala:
+- 2.12.6
+
+script:
+- sbt clean
+- sbt test

--- a/README.md
+++ b/README.md
@@ -1,1 +1,12 @@
 # Sorting leaf nodes in a tree
+
+[![Build Status](https://travis-ci.org/kmusienko/tree-sort-leaf-nodes.svg?branch=master)](https://travis-ci.org/kmusienko/tree-sort-leaf-nodes) 
+
+This is an implementation of an algorithm that sorts leaf nodes in a tree and moves **extra leaf nodes**
+from each node to the next node. If **extra leaf nodes** are present in the last node, they are deleted.
+
+Definition of the **extra leaf nodes**:
+
+If we start iterating over the leaf nodes of a some particular node and count sum of their values,
+**extra leaf nodes** will be a right part of a leaf nodes starting from a node when the sum begins being more
+than given constant **W**.

--- a/build.sbt
+++ b/build.sbt
@@ -1,0 +1,7 @@
+name := "tree"
+
+version := "0.1"
+
+scalaVersion := "2.12.8"
+
+libraryDependencies += "org.scalatest" %% "scalatest" % "3.0.5" % "test"

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version = 1.2.8

--- a/src/main/scala/SinglyLinkedList.scala
+++ b/src/main/scala/SinglyLinkedList.scala
@@ -26,11 +26,11 @@ case class SinglyLinkedList() {
 
   def this(elems: Int*) = {
     this()
-    addAll(elems)
+    addAll(elems.reverse)
   }
 
   /**
-    * Adds a sequence of int elements to the singly linked list.
+    * Adds a sequence of int elements to the singly linked list at the beginning.
     *
     * @param elems elements to be added
     */

--- a/src/main/scala/SinglyLinkedList.scala
+++ b/src/main/scala/SinglyLinkedList.scala
@@ -1,9 +1,24 @@
+/**
+  * Implementation of a singly linked list of integers.
+  */
 case class SinglyLinkedList() {
 
+  /**
+    * Head of the list.
+    */
   var head: Option[Node] = None
 
+  /**
+    * Size of the list
+    */
   var size: Int = 0
 
+  /**
+    * Represents a node of a singly linked list. Singly linked list consists of 'linked' nodes.
+    *
+    * @param value value that associated with this node
+    * @param next  link to the next node
+    */
   case class Node(var value: Int, var next: Option[Node] = None) {
     def print(): Unit = {
       println(value)
@@ -18,6 +33,11 @@ case class SinglyLinkedList() {
     addAll(elems)
   }
 
+  /**
+    * Adds a sequence of int elements to the singly linked list.
+    *
+    * @param elems elements to be added
+    */
   def addAll(elems: Seq[Int]): Unit = {
     elems.foreach {
       elem =>
@@ -28,6 +48,13 @@ case class SinglyLinkedList() {
     size += elems.size
   }
 
+  /**
+    * Iterates over the nodes and removes the rest of the nodes starting from a node when a sum of iterated node values
+    * is more than given constant W.
+    *
+    * @param w given constant
+    * @return list of removed node values
+    */
   def removeAfterSumMoreThanW(w: Int): List[Int] = {
     head match {
       case Some(node) =>
@@ -49,6 +76,12 @@ case class SinglyLinkedList() {
     }
   }
 
+  /**
+    * Removes all the nodes after a specified node.
+    *
+    * @param node node after which the rest of the linked list should be removed
+    * @return list of removed node values
+    */
   def removeAllAfter(node: Node): List[Int] = {
     val removedValues = toScalaList(fromNode = node.next)
     node.next = None
@@ -56,6 +89,12 @@ case class SinglyLinkedList() {
     removedValues
   }
 
+  /**
+    * Creates a Scala List with the values from this SinglyLinkedList with the same order.
+    *
+    * @param fromNode node from which to start copying values
+    * @return new scala list with copied values
+    */
   def toScalaList(fromNode: Option[Node] = head): List[Int] = {
     fromNode match {
       case Some(node) => List(node.value) ++ toScalaList(node.next)
@@ -63,16 +102,26 @@ case class SinglyLinkedList() {
     }
   }
 
+  /**
+    * Sorts the SinglyLinkedList in ascending order.
+    * Actually, it just calls 'mergeSort' method and overrides the head node.
+    */
   def sort(): Unit = {
     head = mergeSort(head)
   }
 
+  /**
+    * Creates a sorted SingleLinkedList in ascending order. Uses Merge Sort algorithm.
+    *
+    * @param maybeNode node to start sorting from
+    * @return sorted SingleLinkedList
+    */
   def mergeSort(maybeNode: Option[Node]): Option[Node] = {
     maybeNode.flatMap {
       node =>
         node.next match {
           case Some(_) =>
-            val maybeMiddle: Option[Node] = getMiddle(node)
+            val maybeMiddle: Option[Node] = findMiddle(node)
             val maybeNextOfMiddle: Option[Node] = maybeMiddle.flatMap(_.next)
 
             maybeMiddle.foreach(_.next = None)
@@ -80,32 +129,43 @@ case class SinglyLinkedList() {
             val maybeLeft = mergeSort(maybeNode)
             val maybeRight = mergeSort(maybeNextOfMiddle)
 
-            val sortedList: Option[Node] = sortedMerge(maybeLeft, maybeRight)
+            val sortedList: Option[Node] = mergeSorted(maybeLeft, maybeRight)
             sortedList
           case _ => Option(node)
         }
     }
   }
 
-  def sortedMerge(maybeNodeA: Option[Node], maybeNodeB: Option[Node]): Option[Node] = {
-    var result: Option[Node] = None
-    (maybeNodeA, maybeNodeB) match {
-      case (None, None) => None
+  /**
+    * Merges two sorted SingleLinkedLists into one.
+    *
+    * @param maybeLeft  left linked list
+    * @param maybeRight right linked list
+    * @return SingleLinkedList as a result of merging left and right lists
+    */
+  def mergeSorted(maybeLeft: Option[Node], maybeRight: Option[Node]): Option[Node] = {
+    (maybeLeft, maybeRight) match {
+      case (Some(nodeA), Some(nodeB)) if nodeA.value <= nodeB.value =>
+        val result = Some(nodeA)
+        result.get.next = mergeSorted(nodeA.next, Some(nodeB))
+        result
+      case (Some(nodeA), Some(nodeB)) =>
+        val result = Some(nodeB)
+        result.get.next = mergeSorted(Some(nodeA), nodeB.next)
+        result
       case (Some(nodeA), None) => Some(nodeA)
       case (None, Some(nodeB)) => Some(nodeB)
-      case (Some(nodeA), Some(nodeB)) =>
-        if (nodeA.value <= nodeB.value) {
-          result = Some(nodeA)
-          result.get.next = sortedMerge(nodeA.next, Some(nodeB))
-        } else {
-          result = Some(nodeB)
-          result.get.next = sortedMerge(Some(nodeA), nodeB.next)
-        }
-        result
+      case (None, None) => None
     }
   }
 
-  def getMiddle(node: Node): Option[Node] = {
+  /**
+    * Finds the middle of the SinglyLinkedList.
+    *
+    * @param node head of the linked list
+    * @return middle node
+    */
+  def findMiddle(node: Node): Option[Node] = {
     var fastPointer: Option[Node] = node.next
     var slowPointer: Option[Node] = Option(node)
 

--- a/src/main/scala/SinglyLinkedList.scala
+++ b/src/main/scala/SinglyLinkedList.scala
@@ -24,6 +24,11 @@ case class SinglyLinkedList() {
     override def toString: String = value.toString + next.fold("")("," + _.toString)
   }
 
+  /**
+    * Constructor that allows for passing elements to add to the SinglyLinkedList.
+    *
+    * @param elems elements to be added to SinglyLinkedList
+    */
   def this(elems: Int*) = {
     this()
     addAll(elems.reverse)

--- a/src/main/scala/SinglyLinkedList.scala
+++ b/src/main/scala/SinglyLinkedList.scala
@@ -1,0 +1,24 @@
+case class SinglyLinkedList() {
+
+  var head: Option[Node] = None
+  var size: Int = 0
+
+  case class Node(var value: Int, var next: Option[Node] = None) {
+    def print(): Unit = {
+      println(value)
+      next.foreach(_.print())
+    }
+
+    override def toString: String = String.valueOf(value) + next.fold("")(_.toString)
+  }
+
+  def print(): Unit = head.foreach(_.print())
+
+  override def toString: String = head.fold("Empty")(_.toString)
+
+  def isEmpty: Boolean = size == 0
+}
+
+object SinglyLinkedList {
+  def empty: SinglyLinkedList = new SinglyLinkedList()
+}

--- a/src/main/scala/SinglyLinkedList.scala
+++ b/src/main/scala/SinglyLinkedList.scala
@@ -20,12 +20,8 @@ case class SinglyLinkedList() {
     * @param next  link to the next node
     */
   case class Node(var value: Int, var next: Option[Node] = None) {
-    def print(): Unit = {
-      println(value)
-      next.foreach(_.print())
-    }
 
-    override def toString: String = String.valueOf(value) + next.fold("")(_.toString)
+    override def toString: String = value.toString + next.fold("")("," + _.toString)
   }
 
   def this(elems: Int*) = {
@@ -180,9 +176,7 @@ case class SinglyLinkedList() {
     slowPointer
   }
 
-  def print(): Unit = head.foreach(_.print())
-
-  override def toString: String = head.fold("Empty")(_.toString)
+  override def toString: String = head.fold("LinkedList()")("LinkedList(" + _.toString + ")")
 
   def isEmpty: Boolean = size == 0
 }

--- a/src/main/scala/SinglyLinkedList.scala
+++ b/src/main/scala/SinglyLinkedList.scala
@@ -27,6 +27,13 @@ case class SinglyLinkedList() {
     size += elems.size
   }
 
+  def toScalaList(fromNode: Option[Node] = head): List[Int] = {
+    fromNode match {
+      case Some(node) => List(node.value) ++ toScalaList(node.next)
+      case _ => List.empty
+    }
+  }
+
   def print(): Unit = head.foreach(_.print())
 
   override def toString: String = head.fold("Empty")(_.toString)

--- a/src/main/scala/SinglyLinkedList.scala
+++ b/src/main/scala/SinglyLinkedList.scala
@@ -178,6 +178,11 @@ case class SinglyLinkedList() {
 
   override def toString: String = head.fold("LinkedList()")("LinkedList(" + _.toString + ")")
 
+  /**
+    * Checks whether this list empty or not
+    *
+    * @return true if the list is empty, false otherwise
+    */
   def isEmpty: Boolean = size == 0
 }
 

--- a/src/main/scala/SinglyLinkedList.scala
+++ b/src/main/scala/SinglyLinkedList.scala
@@ -27,6 +27,35 @@ case class SinglyLinkedList() {
     size += elems.size
   }
 
+  //TODO: rework the code
+  def removeAfterSumMoreThanW(w: Int): List[Int] = {
+    head match {
+      case Some(node) =>
+        var current = node
+        var sum = node.value
+        if (sum > w) {
+          val listValuesToReturn = toScalaList()
+          head = None
+          size -= listValuesToReturn.size
+          return listValuesToReturn
+        }
+
+        while (current.next.nonEmpty) {
+          sum += current.next.get.value
+          if (sum > w) {
+            val listValuesToReturn = toScalaList(fromNode = current.next)
+            current.next = None
+            size -= listValuesToReturn.size
+            return listValuesToReturn
+          }
+          current = current.next.get
+        }
+        List.empty
+
+      case None => List.empty
+    }
+  }
+
   def toScalaList(fromNode: Option[Node] = head): List[Int] = {
     fromNode match {
       case Some(node) => List(node.value) ++ toScalaList(node.next)

--- a/src/main/scala/SinglyLinkedList.scala
+++ b/src/main/scala/SinglyLinkedList.scala
@@ -12,6 +12,21 @@ case class SinglyLinkedList() {
     override def toString: String = String.valueOf(value) + next.fold("")(_.toString)
   }
 
+  def this(elems: Int*) = {
+    this()
+    addAll(elems)
+  }
+
+  def addAll(elems: Seq[Int]): Unit = {
+    elems.foreach {
+      elem =>
+        val newNode = Node(elem)
+        newNode.next = head
+        head = Some(newNode)
+    }
+    size += elems.size
+  }
+
   def print(): Unit = head.foreach(_.print())
 
   override def toString: String = head.fold("Empty")(_.toString)

--- a/src/main/scala/SinglyLinkedList.scala
+++ b/src/main/scala/SinglyLinkedList.scala
@@ -1,6 +1,7 @@
 case class SinglyLinkedList() {
 
   var head: Option[Node] = None
+
   var size: Int = 0
 
   case class Node(var value: Int, var next: Option[Node] = None) {
@@ -27,33 +28,32 @@ case class SinglyLinkedList() {
     size += elems.size
   }
 
-  //TODO: rework the code
   def removeAfterSumMoreThanW(w: Int): List[Int] = {
     head match {
       case Some(node) =>
-        var current = node
         var sum = node.value
         if (sum > w) {
-          val listValuesToReturn = toScalaList()
+          val removedValues = toScalaList()
           head = None
-          size -= listValuesToReturn.size
-          return listValuesToReturn
-        }
-
-        while (current.next.nonEmpty) {
-          sum += current.next.get.value
-          if (sum > w) {
-            val listValuesToReturn = toScalaList(fromNode = current.next)
-            current.next = None
-            size -= listValuesToReturn.size
-            return listValuesToReturn
+          size = 0
+          removedValues
+        } else {
+          var current = node
+          while (current.next.isDefined && (sum + current.next.get.value) <= w) {
+            sum += current.next.get.value
+            current = current.next.get
           }
-          current = current.next.get
+          removeAllAfter(current)
         }
-        List.empty
-
       case None => List.empty
     }
+  }
+
+  def removeAllAfter(node: Node): List[Int] = {
+    val removedValues = toScalaList(fromNode = node.next)
+    node.next = None
+    size -= removedValues.size
+    removedValues
   }
 
   def toScalaList(fromNode: Option[Node] = head): List[Int] = {

--- a/src/main/scala/SinglyLinkedList.scala
+++ b/src/main/scala/SinglyLinkedList.scala
@@ -63,6 +63,63 @@ case class SinglyLinkedList() {
     }
   }
 
+  def sort(): Unit = {
+    head = mergeSort(head)
+  }
+
+  def mergeSort(maybeNode: Option[Node]): Option[Node] = {
+    maybeNode.flatMap {
+      node =>
+        node.next match {
+          case Some(_) =>
+            val maybeMiddle: Option[Node] = getMiddle(node)
+            val maybeNextOfMiddle: Option[Node] = maybeMiddle.flatMap(_.next)
+
+            maybeMiddle.foreach(_.next = None)
+
+            val maybeLeft = mergeSort(maybeNode)
+            val maybeRight = mergeSort(maybeNextOfMiddle)
+
+            val sortedList: Option[Node] = sortedMerge(maybeLeft, maybeRight)
+            sortedList
+          case _ => Option(node)
+        }
+    }
+  }
+
+  def sortedMerge(maybeNodeA: Option[Node], maybeNodeB: Option[Node]): Option[Node] = {
+    var result: Option[Node] = None
+    (maybeNodeA, maybeNodeB) match {
+      case (None, None) => None
+      case (Some(nodeA), None) => Some(nodeA)
+      case (None, Some(nodeB)) => Some(nodeB)
+      case (Some(nodeA), Some(nodeB)) =>
+        if (nodeA.value <= nodeB.value) {
+          result = Some(nodeA)
+          result.get.next = sortedMerge(nodeA.next, Some(nodeB))
+        } else {
+          result = Some(nodeB)
+          result.get.next = sortedMerge(Some(nodeA), nodeB.next)
+        }
+        result
+    }
+  }
+
+  def getMiddle(node: Node): Option[Node] = {
+    var fastPointer: Option[Node] = node.next
+    var slowPointer: Option[Node] = Option(node)
+
+    while (fastPointer.isDefined) {
+      fastPointer = fastPointer.get.next
+      fastPointer.foreach {
+        fastPointerValue =>
+          slowPointer = slowPointer.get.next
+          fastPointer = fastPointerValue.next
+      }
+    }
+    slowPointer
+  }
+
   def print(): Unit = head.foreach(_.print())
 
   override def toString: String = head.fold("Empty")(_.toString)

--- a/src/main/scala/TreeNode.scala
+++ b/src/main/scala/TreeNode.scala
@@ -1,0 +1,4 @@
+import scala.collection.immutable.Queue
+
+case class TreeNode(nodes: Queue[TreeNode] = Queue.empty,
+                    leafList: SinglyLinkedList = SinglyLinkedList.empty)

--- a/src/main/scala/TreeNode.scala
+++ b/src/main/scala/TreeNode.scala
@@ -5,6 +5,12 @@ import scala.collection.immutable.Queue
 case class TreeNode(nodes: Queue[TreeNode] = Queue.empty,
                     leafList: SinglyLinkedList = SinglyLinkedList.empty) {
 
+
+  def sortLeafNodes(traversalType: TraversalType, w: Int): Unit = {
+    val iterator: Iterator[TreeNode] = traversalType.iterator[TreeNode](this, _.nodes)
+    sortLeafNodes(iterator, w)
+  }
+
   private def sortLeafNodes(iterator: Iterator[TreeNode], w: Int): Unit = {
     if (leafList.isEmpty) {
       if (iterator.hasNext) {

--- a/src/main/scala/TreeNode.scala
+++ b/src/main/scala/TreeNode.scala
@@ -1,4 +1,24 @@
+import TreeTraversalTypes.TraversalType
+
 import scala.collection.immutable.Queue
 
 case class TreeNode(nodes: Queue[TreeNode] = Queue.empty,
-                    leafList: SinglyLinkedList = SinglyLinkedList.empty)
+                    leafList: SinglyLinkedList = SinglyLinkedList.empty) {
+
+  private def sortLeafNodes(iterator: Iterator[TreeNode], w: Int): Unit = {
+    if (leafList.isEmpty) {
+      if (iterator.hasNext) {
+        val next = iterator.next
+        next.sortLeafNodes(iterator, w)
+      }
+    } else {
+      leafList.sort()
+      val removedValues = leafList.removeAfterSumMoreThanW(w)
+      if (iterator.hasNext) {
+        val nextNode = iterator.next()
+        nextNode.leafList.addAll(removedValues)
+        nextNode.sortLeafNodes(iterator, w)
+      }
+    }
+  }
+}

--- a/src/main/scala/TreeNode.scala
+++ b/src/main/scala/TreeNode.scala
@@ -2,15 +2,45 @@ import TreeTraversalTypes.TraversalType
 
 import scala.collection.immutable.Queue
 
+/**
+  * Implementation of a tree.
+  *
+  * @param nodes    queue of nodes of the current tree node
+  * @param leafList singly linked list of leaf nodes of the current tree node
+  */
 case class TreeNode(nodes: Queue[TreeNode] = Queue.empty,
                     leafList: SinglyLinkedList = SinglyLinkedList.empty) {
 
 
+  /**
+    * Sorts leaf nodes in a tree and deletes extra leaf nodes from each node.
+    *
+    * Definition of extra leaf nodes:
+    *
+    * If we start iterating over the leaf nodes of a some particular node and count sum of their values,
+    * extra leaf nodes will be a right part of a leaf nodes starting from a node when the sum begins being more than
+    * given constant W.
+    *
+    * @param traversalType a way to traverse the tree
+    * @param w             given constant W
+    */
   def sortLeafNodes(traversalType: TraversalType, w: Int): Unit = {
     val iterator: Iterator[TreeNode] = traversalType.iterator[TreeNode](this, _.nodes)
     sortLeafNodes(iterator, w)
   }
 
+  /**
+    * Sorts leaf nodes in a tree and deletes extra leaf nodes from each node.
+    *
+    * Definition of extra leaf nodes:
+    *
+    * If we start iterating over the leaf nodes of a some particular node and count sum of their values,
+    * extra leaf nodes will be a right part of a leaf nodes starting from a node when the sum begins being more than
+    * given constant W.
+    *
+    * @param iterator iterator to traverse the tree
+    * @param w        given constant W
+    */
   def sortLeafNodes(iterator: Iterator[TreeNode], w: Int): Unit = {
     if (leafList.isEmpty) {
       if (iterator.hasNext) {

--- a/src/main/scala/TreeNode.scala
+++ b/src/main/scala/TreeNode.scala
@@ -11,7 +11,7 @@ case class TreeNode(nodes: Queue[TreeNode] = Queue.empty,
     sortLeafNodes(iterator, w)
   }
 
-  private def sortLeafNodes(iterator: Iterator[TreeNode], w: Int): Unit = {
+  def sortLeafNodes(iterator: Iterator[TreeNode], w: Int): Unit = {
     if (leafList.isEmpty) {
       if (iterator.hasNext) {
         val next = iterator.next

--- a/src/main/scala/TreeNode.scala
+++ b/src/main/scala/TreeNode.scala
@@ -13,9 +13,11 @@ case class TreeNode(nodes: Queue[TreeNode] = Queue.empty,
 
 
   /**
-    * Sorts leaf nodes in a tree and deletes extra leaf nodes from each node.
+    * Sorts leaf nodes in a tree and moves extra leaf nodes from each node to the next node.
     *
-    * Definition of extra leaf nodes:
+    * If extra leaf nodes are present in the last node, they are deleted.
+    *
+    * Definition of the extra leaf nodes:
     *
     * If we start iterating over the leaf nodes of a some particular node and count sum of their values,
     * extra leaf nodes will be a right part of a leaf nodes starting from a node when the sum begins being more than
@@ -30,7 +32,9 @@ case class TreeNode(nodes: Queue[TreeNode] = Queue.empty,
   }
 
   /**
-    * Sorts leaf nodes in a tree and deletes extra leaf nodes from each node.
+    * Sorts leaf nodes in a tree and moves extra leaf nodes from each node to the next node.
+    *
+    * If extra leaf nodes are present in the last node, they are deleted.
     *
     * Definition of extra leaf nodes:
     *

--- a/src/main/scala/TreeTraversalTypes.scala
+++ b/src/main/scala/TreeTraversalTypes.scala
@@ -5,4 +5,18 @@ object TreeTraversalTypes {
   sealed trait TraversalType {
     def iterator[Node](node: Node, f: Node => Queue[Node]): Iterator[Node]
   }
+
+  case object BreadthFirst extends TraversalType {
+    override def iterator[Node](node: Node, f: Node => Queue[Node]): Iterator[Node] = {
+      def recurse(q: Queue[Node]): List[Node] = {
+        if (q.isEmpty) List.empty
+        else {
+          val (node, tail) = q.dequeue
+          node :: recurse(tail ++ f(node))
+        }
+      }
+
+      (node :: recurse(Queue.empty ++ f(node))).toIterator
+    }
+  }
 }

--- a/src/main/scala/TreeTraversalTypes.scala
+++ b/src/main/scala/TreeTraversalTypes.scala
@@ -26,7 +26,7 @@ object TreeTraversalTypes {
     */
   case object BreadthFirst extends TraversalType {
 
-    /** @inheritdoc*/
+    /** @inheritdoc */
     override def iterator[Node](node: Node, f: Node => Queue[Node]): Iterator[Node] = {
       def recurse(q: Queue[Node]): List[Node] = {
         if (q.isEmpty) List.empty

--- a/src/main/scala/TreeTraversalTypes.scala
+++ b/src/main/scala/TreeTraversalTypes.scala
@@ -1,0 +1,8 @@
+import scala.collection.immutable.Queue
+
+object TreeTraversalTypes {
+
+  sealed trait TraversalType {
+    def iterator[Node](node: Node, f: Node => Queue[Node]): Iterator[Node]
+  }
+}

--- a/src/main/scala/TreeTraversalTypes.scala
+++ b/src/main/scala/TreeTraversalTypes.scala
@@ -1,12 +1,32 @@
 import scala.collection.immutable.Queue
 
+/**
+  * An object where tree traversal types are defined.
+  */
 object TreeTraversalTypes {
 
+  /**
+    * Trait that declares an iterator by which a tree can be traversed.
+    */
   sealed trait TraversalType {
+
+    /**
+      * Returns an iterator by which a tree can be traversed.
+      *
+      * @param node tree node to start traverse from
+      * @param f    function that takes a parent Node as an argument and returns a Queue containing all its children
+      * @tparam Node type of the tree node
+      * @return iterator by which a tree can traversed.
+      */
     def iterator[Node](node: Node, f: Node => Queue[Node]): Iterator[Node]
   }
 
+  /**
+    * The Breadth First Traversal type with provided iterator.
+    */
   case object BreadthFirst extends TraversalType {
+
+    /** @inheritdoc*/
     override def iterator[Node](node: Node, f: Node => Queue[Node]): Iterator[Node] = {
       def recurse(q: Queue[Node]): List[Node] = {
         if (q.isEmpty) List.empty
@@ -19,4 +39,5 @@ object TreeTraversalTypes {
       (node :: recurse(Queue.empty ++ f(node))).toIterator
     }
   }
+
 }

--- a/src/test/scala/TreeSpec.scala
+++ b/src/test/scala/TreeSpec.scala
@@ -1,0 +1,101 @@
+import TreeTraversalTypes.BreadthFirst
+import org.scalatest.{BeforeAndAfter, MustMatchers, WordSpec}
+
+import scala.collection.immutable.Queue
+
+class TreeSpec extends WordSpec with BeforeAndAfter with MustMatchers {
+
+  "TreeSpec" must {
+    "sort leaf nodes in tree #1 where w = 5" in {
+      val tree =
+        TreeNode(
+          nodes = Queue(
+            TreeNode(
+              leafList = new SinglyLinkedList(2, 1, 4, 3)
+            ),
+            TreeNode(
+              nodes = Queue(
+                TreeNode(
+                  leafList = new SinglyLinkedList(1, 1)
+                )
+              ),
+              leafList = new SinglyLinkedList(2)
+            )
+          )
+        )
+
+      tree.sortLeafNodes(traversalType = BreadthFirst, w = 5)
+
+      tree.leafList mustBe empty
+      tree.nodes.head.leafList.toScalaList() mustBe List(1, 2)
+      tree.nodes(1).leafList.toScalaList() mustBe List(2, 3)
+      tree.nodes(1).nodes.head.leafList.toScalaList() mustBe List(1, 1)
+      tree.nodes(1).nodes.head.nodes mustBe empty
+    }
+
+    "sort leaf nodes in tree #1 where w = 3" in {
+      val tree =
+        TreeNode(
+          nodes = Queue(
+            TreeNode(
+              leafList = new SinglyLinkedList(2, 1, 4, 3)
+            ),
+            TreeNode(
+              nodes = Queue(
+                TreeNode(
+                  leafList = new SinglyLinkedList(1, 1)
+                )
+              ),
+              leafList = new SinglyLinkedList(2)
+            )
+          )
+        )
+
+      tree.sortLeafNodes(traversalType = BreadthFirst, w = 3)
+
+      tree.leafList mustBe empty
+      tree.nodes.head.leafList.toScalaList() mustBe List(1, 2)
+      tree.nodes(1).leafList.toScalaList() mustBe List(2)
+      tree.nodes(1).nodes.head.leafList.toScalaList() mustBe List(1, 1)
+      tree.nodes(1).nodes.head.nodes mustBe empty
+    }
+
+    "sort leaf nodes in tree #2 where w = 5" in {
+      val tree =
+        TreeNode(
+          nodes = Queue(
+            TreeNode(),
+            TreeNode(),
+            TreeNode(),
+          ),
+          leafList = new SinglyLinkedList(3, 4, 1, 2)
+        )
+
+      tree.sortLeafNodes(traversalType = BreadthFirst, w = 5)
+
+      tree.leafList.toScalaList() mustBe List(1, 2)
+      tree.nodes.head.leafList.toScalaList() mustBe List(3)
+      tree.nodes(1).leafList.toScalaList() mustBe List(4)
+      tree.nodes(2).leafList mustBe empty
+    }
+
+    "sort leaf nodes in tree #2 where w = 3" in {
+      val tree =
+        TreeNode(
+          nodes = Queue(
+            TreeNode(),
+            TreeNode(),
+            TreeNode(),
+          ),
+          leafList = new SinglyLinkedList(3, 4, 1, 2)
+        )
+
+      tree.sortLeafNodes(traversalType = BreadthFirst, w = 3)
+
+      tree.leafList.toScalaList() mustBe List(1, 2)
+      tree.nodes.head.leafList.toScalaList() mustBe List(3)
+      tree.nodes(1).leafList mustBe empty
+      tree.nodes(2).leafList mustBe empty
+    }
+  }
+}

--- a/src/test/scala/TreeSpec.scala
+++ b/src/test/scala/TreeSpec.scala
@@ -6,6 +6,33 @@ import scala.collection.immutable.Queue
 class TreeSpec extends WordSpec with BeforeAndAfter with MustMatchers {
 
   "TreeSpec" must {
+    "sort leaf nodes in tree #1 where w = 0 (all leaf nodes should be removed)" in {
+      val tree =
+        TreeNode(
+          nodes = Queue(
+            TreeNode(
+              leafList = new SinglyLinkedList(2, 1, 4, 3)
+            ),
+            TreeNode(
+              nodes = Queue(
+                TreeNode(
+                  leafList = new SinglyLinkedList(1, 1)
+                )
+              ),
+              leafList = new SinglyLinkedList(2)
+            )
+          )
+        )
+
+      tree.sortLeafNodes(traversalType = BreadthFirst, w = 0)
+
+      tree.leafList mustBe empty
+      tree.nodes.head.leafList mustBe empty
+      tree.nodes(1).leafList mustBe empty
+      tree.nodes(1).nodes.head.leafList mustBe empty
+      tree.nodes(1).nodes.head.nodes mustBe empty
+    }
+
     "sort leaf nodes in tree #1 where w = 5" in {
       val tree =
         TreeNode(
@@ -60,6 +87,52 @@ class TreeSpec extends WordSpec with BeforeAndAfter with MustMatchers {
       tree.nodes(1).nodes.head.nodes mustBe empty
     }
 
+    "sort leaf nodes in tree #1 where w = 100 (the tree shouldn't be changed except sorting leaf nodes)" in {
+      val tree =
+        TreeNode(
+          nodes = Queue(
+            TreeNode(
+              leafList = new SinglyLinkedList(2, 1, 4, 3)
+            ),
+            TreeNode(
+              nodes = Queue(
+                TreeNode(
+                  leafList = new SinglyLinkedList(1, 1)
+                )
+              ),
+              leafList = new SinglyLinkedList(2)
+            )
+          )
+        )
+
+      tree.sortLeafNodes(traversalType = BreadthFirst, w = 100)
+
+      tree.leafList mustBe empty
+      tree.nodes.head.leafList.toScalaList() mustBe List(1, 2, 3, 4)
+      tree.nodes(1).leafList.toScalaList() mustBe List(2)
+      tree.nodes(1).nodes.head.leafList.toScalaList() mustBe List(1, 1)
+      tree.nodes(1).nodes.head.nodes mustBe empty
+    }
+
+    "sort leaf nodes in tree #2 where w = 0 (all leaf nodes should be removed)" in {
+      val tree =
+        TreeNode(
+          nodes = Queue(
+            TreeNode(),
+            TreeNode(),
+            TreeNode(),
+          ),
+          leafList = new SinglyLinkedList(3, 4, 1, 2)
+        )
+
+      tree.sortLeafNodes(traversalType = BreadthFirst, w = 0)
+
+      tree.leafList mustBe empty
+      tree.nodes.head.leafList mustBe empty
+      tree.nodes(1).leafList mustBe empty
+      tree.nodes(2).leafList mustBe empty
+    }
+
     "sort leaf nodes in tree #2 where w = 5" in {
       val tree =
         TreeNode(
@@ -94,6 +167,25 @@ class TreeSpec extends WordSpec with BeforeAndAfter with MustMatchers {
 
       tree.leafList.toScalaList() mustBe List(1, 2)
       tree.nodes.head.leafList.toScalaList() mustBe List(3)
+      tree.nodes(1).leafList mustBe empty
+      tree.nodes(2).leafList mustBe empty
+    }
+
+    "sort leaf nodes in tree #2 where w = 100 (the tree shouldn't be changed except sorting leaf nodes)" in {
+      val tree =
+        TreeNode(
+          nodes = Queue(
+            TreeNode(),
+            TreeNode(),
+            TreeNode(),
+          ),
+          leafList = new SinglyLinkedList(3, 4, 1, 2)
+        )
+
+      tree.sortLeafNodes(traversalType = BreadthFirst, w = 100)
+
+      tree.leafList.toScalaList() mustBe List(1, 2, 3, 4)
+      tree.nodes.head.leafList mustBe empty
       tree.nodes(1).leafList mustBe empty
       tree.nodes(2).leafList mustBe empty
     }


### PR DESCRIPTION
This pull-request contains implementation of an algorithm that sorts leaf nodes in a tree and and moves **extra leaf nodes** from each node to the next node. If **extra leaf nodes** are present in the last node, they are deleted.

Definition of **extra leaf nodes**:

If we start iterating over the leaf nodes of a some particular node and count sum of their values, **extra leaf nodes** will be a right part of a leaf nodes starting from a node when the sum begins being more than given constant W.